### PR TITLE
fix(typescript): fix tsconfig generator producing wrong ecore path

### DIFF
--- a/src/com/crossecore/typescript/NpmPackageGenerator.xtend
+++ b/src/com/crossecore/typescript/NpmPackageGenerator.xtend
@@ -45,7 +45,7 @@ class NpmPackageGenerator extends EcoreVisitor{
 		  "main": "lib/index.js",
 		  "private": true,
 		  "dependencies": {
-		  	"crossecore": "^0.1.0"
+		  	"crossecore": "^0.3.0"
 		  },
 		  "devDependencies": {
 		    "typescript": "~3.5.2",

--- a/src/com/crossecore/typescript/TSConfigGenerator.xtend
+++ b/src/com/crossecore/typescript/TSConfigGenerator.xtend
@@ -40,7 +40,7 @@ class TSConfigGenerator extends EcoreVisitor{
 		  "compilerOptions": {
 		    "baseUrl": "./",
 		    "paths": {
-		      "ecore/*": ["node_modules/crossecore/lib/*"],
+		      "ecore/*": ["node_modules/crossecore/typings/*"],
 		      "«epackage.name»/*": ["./*"]
 		    },    
 		    "outDir": "./dist/out-tsc",


### PR DESCRIPTION
In `crossecore` `v0.3.0` typings are exposed under the `typings` directory.